### PR TITLE
Add missing parameter to generate_grid_basis call

### DIFF
--- a/bps/bps.py
+++ b/bps/bps.py
@@ -225,7 +225,7 @@ def encode(x, bps_arrangement='random', n_bps_points=512, radius=1.5, bps_cell_t
         elif bps_arrangement == 'grid':
             # in case of a grid basis, we need to find the nearest possible grid size
             grid_size = int(np.round(np.power(n_bps_points, 1 / n_dims)))
-            basis_set = generate_grid_basis(grid_size=grid_size, minv=-radius, maxv=radius)
+            basis_set = generate_grid_basis(grid_size=grid_size, minv=-radius, maxv=radius, n_dims=n_dims)
         elif bps_arrangement == 'custom':
             # in case of a grid basis, we need to find the nearest possible grid size
             if custom_basis is not None:


### PR DESCRIPTION
This PR fixes #2 

Simply passing `n_dims` when calling `generate_grid_basis` fixes the bug.